### PR TITLE
Add interactive FastAPI GUI for HLSF visualisations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
   "numpy>=1.26",
   "networkx>=3.2",
   "requests>=2.31",
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.23",
 ]
 
 [project.scripts]

--- a/src/hlsf/analysis.py
+++ b/src/hlsf/analysis.py
@@ -1,0 +1,95 @@
+"""Analytical helpers for HLSF visualisations."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, List, Mapping
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - environment without numpy
+    np = None
+
+
+def fft_magnitude_series(values: Iterable[float]) -> List[Dict[str, float]]:
+    """Return the magnitude spectrum for a sequence of scalar values.
+
+    The FFT is computed using ``numpy.fft.rfft`` so the output only contains
+    the non-negative frequency components. The resulting magnitudes are
+    returned as a list of dictionaries which is convenient for serialising to
+    JSON for the web UI.
+    """
+
+    data = [float(v) for v in values]
+    n = len(data)
+    if n == 0:
+        return []
+
+    if np is not None:
+        arr = np.array(data, dtype=float)
+        arr = arr - arr.mean()
+        spectrum = np.fft.rfft(arr)
+        freqs = np.fft.rfftfreq(arr.size, d=1.0)
+        mags = np.abs(spectrum)
+        max_mag = mags.max(initial=0.0)
+        if max_mag > 0.0:
+            mags = mags / max_mag
+        return [
+            {"freq": float(freq), "magnitude": float(mag)}
+            for freq, mag in zip(freqs, mags)
+        ]
+
+    # Fallback: compute a naive DFT when numpy is unavailable.
+    mean = sum(data) / n
+    centered = [v - mean for v in data]
+    spectrum = []
+    half_n = n // 2
+    for k in range(half_n + 1):
+        real = 0.0
+        imag = 0.0
+        for t, val in enumerate(centered):
+            angle = 2 * math.pi * k * t / n
+            real += val * math.cos(angle)
+            imag -= val * math.sin(angle)
+        magnitude = math.sqrt(real * real + imag * imag)
+        spectrum.append((k / n, magnitude))
+    max_mag = max((m for _, m in spectrum), default=0.0)
+    if max_mag > 0.0:
+        spectrum = [(freq, mag / max_mag) for freq, mag in spectrum]
+    return [{"freq": freq, "magnitude": mag} for freq, mag in spectrum]
+
+
+def glyph_stream(
+    tokens: Iterable[str],
+    expansions: Mapping[str, List[str]],
+    glyph_lookup: Mapping[str, str],
+) -> List[Dict[str, str]]:
+    """Build an ordered glyph stream for the UI.
+
+    The glyph stream interleaves the seed tokens and their two expansions so
+    the front-end can display how symbolic glyphs propagate through the
+    High-Level Space Field.
+    """
+
+    stream: List[Dict[str, str]] = []
+    for idx, tok in enumerate(tokens):
+        stream.append(
+            {
+                "id": f"t{idx}",
+                "text": tok,
+                "kind": "token",
+                "glyph": glyph_lookup.get(tok, "?"),
+            }
+        )
+        exps = expansions.get(tok, [])
+        for e_idx, exp in enumerate(exps[:2]):
+            stream.append(
+                {
+                    "id": f"t{idx}_e{e_idx+1}",
+                    "text": exp,
+                    "kind": "expansion",
+                    "glyph": glyph_lookup.get(exp, "?"),
+                }
+            )
+    return stream
+

--- a/src/hlsf/cli.py
+++ b/src/hlsf/cli.py
@@ -18,6 +18,11 @@ def main():
     pr.add_argument("--passes", type=int, default=None, help="Refinement passes (>=1)")
     pr.add_argument("--no-llm", action="store_true", help="Disable LLM usage")
 
+    pg = sub.add_parser("gui", help="Launch the interactive web interface")
+    pg.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind the GUI server")
+    pg.add_argument("--port", type=int, default=8000, help="Port for the GUI server")
+    pg.add_argument("--no-browser", action="store_true", help="Do not open a browser window")
+
     args = p.parse_args()
     if args.cmd == "run":
         s = Settings()
@@ -35,5 +40,9 @@ def main():
 
         pkg, answer = run_hlsf(args.prompt, args.json_out, args.text_out, s)
         print(f"Wrote {args.json_out} and {args.text_out}")
+    elif args.cmd == "gui":
+        from .web.app import run_gui
+
+        run_gui(host=args.host, port=args.port, open_browser=not args.no_browser)
     else:
         p.print_help()

--- a/src/hlsf/web/__init__.py
+++ b/src/hlsf/web/__init__.py
@@ -1,0 +1,5 @@
+"""Web UI for the HLSF engine."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/hlsf/web/app.py
+++ b/src/hlsf/web/app.py
@@ -1,0 +1,74 @@
+"""FastAPI application exposing the interactive HLSF GUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from ..pipeline import run_hlsf_in_memory
+from ..settings import Settings
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+class RunPayload(BaseModel):
+    prompt: str
+    use_llm: Optional[bool] = None
+    passes: Optional[int] = None
+
+
+def create_app() -> FastAPI:
+    settings = Settings()
+    app = FastAPI(title="HLSF Visual Cortex", version=settings.version)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+    @app.get("/")
+    async def index() -> FileResponse:
+        index_file = STATIC_DIR / "index.html"
+        if not index_file.exists():
+            raise HTTPException(status_code=500, detail="UI assets missing")
+        return FileResponse(index_file)
+
+    @app.post("/api/run")
+    async def run(payload: RunPayload):
+        if not payload.prompt.strip():
+            raise HTTPException(status_code=422, detail="Prompt cannot be empty")
+        settings = Settings()
+        if payload.use_llm is not None:
+            settings.use_llm = payload.use_llm
+        if payload.passes is not None:
+            settings.refine_passes = max(1, int(payload.passes))
+        pkg, answer = run_hlsf_in_memory(payload.prompt, settings)
+        return {"package": pkg, "answer": answer}
+
+    return app
+
+
+def run_gui(host: str = "127.0.0.1", port: int = 8000, open_browser: bool = True) -> None:
+    import threading
+    import webbrowser
+
+    import uvicorn
+
+    app = create_app()
+
+    if open_browser:
+        url = f"http://{host}:{port}"
+        threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/src/hlsf/web/static/app.js
+++ b/src/hlsf/web/static/app.js
@@ -1,0 +1,279 @@
+const form = document.getElementById("prompt-form");
+const promptInput = document.getElementById("prompt-input");
+const useLlmInput = document.getElementById("use-llm");
+const passesInput = document.getElementById("passes");
+const statusEl = document.getElementById("status");
+const answerOutput = document.getElementById("answer-output");
+const statsList = document.getElementById("stats");
+
+const graphSvg = d3.select("#graph");
+const fftSvg = d3.select("#fft-chart");
+const glyphContainer = document.getElementById("glyph-stream");
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const prompt = promptInput.value.trim();
+  if (!prompt) {
+    statusEl.textContent = "Enter a prompt to generate a field.";
+    return;
+  }
+
+  statusEl.textContent = "Synthesizing space field...";
+  answerOutput.textContent = "";
+  statsList.innerHTML = "";
+  glyphContainer.innerHTML = "";
+  clearSvg(graphSvg);
+  clearSvg(fftSvg);
+
+  try {
+    const response = await fetch("/api/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt,
+        use_llm: useLlmInput.checked,
+        passes: parseInt(passesInput.value, 10) || 1,
+      }),
+    });
+
+    if (!response.ok) {
+      const problem = await response.json();
+      throw new Error(problem.detail || "Request failed");
+    }
+
+    const payload = await response.json();
+    statusEl.textContent = "Field ready.";
+    renderAnswer(payload.answer);
+    renderStats(payload.package.stats);
+    renderGraph(payload.package.space_field);
+    renderFFT(payload.package.analytics.fft.tokens);
+    renderGlyphStream(payload.package.analytics.glyph_stream);
+  } catch (err) {
+    console.error(err);
+    statusEl.textContent = `Error: ${err.message}`;
+  }
+});
+
+function clearSvg(svg) {
+  svg.selectAll("*").remove();
+}
+
+function renderAnswer(answer) {
+  answerOutput.textContent = answer.trim();
+}
+
+function renderStats(stats) {
+  statsList.innerHTML = "";
+  Object.entries(stats || {}).forEach(([key, value]) => {
+    const li = document.createElement("li");
+    li.innerHTML = `<strong>${value}</strong><div>${key}</div>`;
+    statsList.appendChild(li);
+  });
+}
+
+function renderGraph(spaceField) {
+  const width = 800;
+  const height = 520;
+  clearSvg(graphSvg);
+
+  const tokens = (spaceField.tokens || []).map((n) => ({
+    ...n,
+    kind: "token",
+  }));
+  const expansions = (spaceField.expansions || []).map((n) => ({
+    ...n,
+    kind: "expansion",
+  }));
+  const nodes = [...tokens, ...expansions];
+  const links = (spaceField.edges || []).map((e) => ({
+    source: e.a,
+    target: e.b,
+    weight: e.k,
+  }));
+
+  if (!nodes.length) {
+    graphSvg.append("text")
+      .attr("x", width / 2)
+      .attr("y", height / 2)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#94a3b8")
+      .text("No graph data");
+    return;
+  }
+
+  const xExtent = padExtent(d3.extent(nodes, (d) => d.pos[0]));
+  const yExtent = padExtent(d3.extent(nodes, (d) => d.pos[1]));
+  const xScale = d3.scaleLinear().domain(xExtent).range([40, width - 40]);
+  const yScale = d3.scaleLinear().domain(yExtent).range([40, height - 40]);
+
+  nodes.forEach((node) => {
+    node.x = xScale(node.pos[0]);
+    node.y = yScale(node.pos[1]);
+  });
+
+  const simulation = d3
+    .forceSimulation(nodes)
+    .force(
+      "link",
+      d3
+        .forceLink(links)
+        .id((d) => d.id)
+        .distance((d) => 140 - 40 * (d.weight || 0))
+        .strength(0.8)
+    )
+    .force("charge", d3.forceManyBody().strength((d) => (d.kind === "token" ? -200 : -80)))
+    .force("center", d3.forceCenter(width / 2, height / 2))
+    .alphaDecay(0.08);
+
+  const link = graphSvg
+    .append("g")
+    .attr("stroke", "rgba(148, 163, 184, 0.35)")
+    .attr("stroke-width", 1.5)
+    .selectAll("line")
+    .data(links)
+    .enter()
+    .append("line")
+    .attr("class", "link");
+
+  const node = graphSvg
+    .append("g")
+    .selectAll("g")
+    .data(nodes)
+    .enter()
+    .append("g")
+    .attr("class", "node")
+    .call(
+      d3
+        .drag()
+        .on("start", (event, d) => {
+          if (!event.active) simulation.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on("drag", (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on("end", (event, d) => {
+          if (!event.active) simulation.alphaTarget(0);
+          d.fx = null;
+          d.fy = null;
+        })
+    );
+
+  node
+    .append("circle")
+    .attr("r", (d) => (d.kind === "token" ? 22 : 16))
+    .attr("fill", (d) => (d.kind === "token" ? "#38bdf8" : "#818cf8"))
+    .attr("fill-opacity", (d) => (d.kind === "token" ? 0.35 : 0.25));
+
+  node
+    .append("text")
+    .attr("text-anchor", "middle")
+    .attr("dy", "0.35em")
+    .text((d) => d.glyph || d.text.slice(0, 2));
+
+  node
+    .append("title")
+    .text((d) => `${d.kind.toUpperCase()} :: ${d.text}`);
+
+  simulation.on("tick", () => {
+    link
+      .attr("x1", (d) => d.source.x)
+      .attr("y1", (d) => d.source.y)
+      .attr("x2", (d) => d.target.x)
+      .attr("y2", (d) => d.target.y);
+
+    node.attr("transform", (d) => `translate(${d.x}, ${d.y})`);
+  });
+}
+
+function renderFFT(series) {
+  const width = 800;
+  const height = 240;
+  clearSvg(fftSvg);
+
+  if (!series || !series.length) {
+    fftSvg
+      .append("text")
+      .attr("x", width / 2)
+      .attr("y", height / 2)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#94a3b8")
+      .text("No FFT data");
+    return;
+  }
+
+  const margin = { top: 20, right: 20, bottom: 35, left: 50 };
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+
+  const g = fftSvg
+    .append("g")
+    .attr("transform", `translate(${margin.left}, ${margin.top})`);
+
+  const maxFreq = d3.max(series, (d) => d.freq) || 1;
+  const maxMag = d3.max(series, (d) => d.magnitude) || 1;
+  const x = d3.scaleLinear().domain([0, maxFreq]).range([0, innerWidth]);
+  const y = d3.scaleLinear().domain([0, maxMag]).range([innerHeight, 0]);
+
+  const line = d3
+    .line()
+    .x((d) => x(d.freq))
+    .y((d) => y(d.magnitude))
+    .curve(d3.curveMonotoneX);
+
+  g.append("path")
+    .datum(series)
+    .attr("fill", "none")
+    .attr("stroke", "#38bdf8")
+    .attr("stroke-width", 2)
+    .attr("d", line);
+
+  g.append("g").attr("transform", `translate(0, ${innerHeight})`).call(d3.axisBottom(x));
+  g.append("g").call(d3.axisLeft(y));
+
+  g.append("text")
+    .attr("x", innerWidth)
+    .attr("y", innerHeight + 30)
+    .attr("text-anchor", "end")
+    .attr("fill", "#94a3b8")
+    .text("Frequency");
+
+  g.append("text")
+    .attr("x", -20)
+    .attr("y", -8)
+    .attr("text-anchor", "start")
+    .attr("fill", "#94a3b8")
+    .text("Magnitude");
+}
+
+function renderGlyphStream(stream) {
+  glyphContainer.innerHTML = "";
+  if (!stream || !stream.length) {
+    glyphContainer.textContent = "No glyphs available.";
+    return;
+  }
+
+  stream.forEach((entry) => {
+    const card = document.createElement("div");
+    card.className = "glyph-card";
+    card.innerHTML = `
+      <div class="label">${entry.kind}</div>
+      <div class="glyph">${entry.glyph || "?"}</div>
+      <div class="text">${entry.text}</div>
+    `;
+    glyphContainer.appendChild(card);
+  });
+}
+
+function padExtent(extent) {
+  const [min, max] = extent;
+  if (min === undefined || max === undefined) {
+    return [-1, 1];
+  }
+  if (min === max) {
+    return [min - 1, max + 1];
+  }
+  return extent;
+}

--- a/src/hlsf/web/static/index.html
+++ b/src/hlsf/web/static/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>HLSF Visual Cortex</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js" defer></script>
+    <script src="/static/app.js" defer></script>
+  </head>
+  <body>
+    <header>
+      <h1>HLSF Visual Cortex</h1>
+      <p class="subtitle">
+        Real-time exploration of High-Level Space Fields powered by the default ChatGPT 4o-mini stack.
+      </p>
+    </header>
+
+    <main>
+      <section class="panel" id="control-panel">
+        <form id="prompt-form">
+          <label for="prompt-input">Prompt</label>
+          <textarea id="prompt-input" rows="4" placeholder="Describe a double pendulum to a curious student."></textarea>
+
+          <div class="options">
+            <label><input type="checkbox" id="use-llm" checked /> Use live LLM (gpt-4o-mini)</label>
+            <label>
+              Refinement passes
+              <input type="number" id="passes" min="1" max="5" value="2" />
+            </label>
+          </div>
+
+          <button type="submit">Synthesize Field</button>
+          <span class="status" id="status"></span>
+        </form>
+
+        <div class="panel" id="answer-panel">
+          <h2>Final Answer</h2>
+          <pre id="answer-output"></pre>
+        </div>
+
+        <div class="panel" id="stats-panel">
+          <h2>Space Field Stats</h2>
+          <ul id="stats"></ul>
+        </div>
+      </section>
+
+      <section class="panel wide" id="visual-panel">
+        <div class="viz" id="graph-container">
+          <h2>HLSF Graph</h2>
+          <svg id="graph" viewBox="0 0 800 520"></svg>
+        </div>
+        <div class="viz" id="fft-container">
+          <h2>FFT of Vector Numbers</h2>
+          <svg id="fft-chart" viewBox="0 0 800 240"></svg>
+        </div>
+        <div class="viz" id="glyph-container">
+          <h2>Symbolic Glyph Stream</h2>
+          <div id="glyph-stream"></div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Default provider: <strong>ChatGPT 4o-mini</strong>. Configure credentials with environment variables when launching the GUI via <code>hlsf gui</code>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/src/hlsf/web/static/styles.css
+++ b/src/hlsf/web/static/styles.css
@@ -1,0 +1,209 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at top left, #1e293b 0%, #0f172a 60%);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header,
+footer {
+  padding: 1.5rem 2rem;
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(8px);
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin: 0.4rem 0 0;
+  color: #94a3b8;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  grid-template-columns: 320px 1fr;
+}
+
+.panel {
+  background: rgba(30, 41, 59, 0.85);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.panel.wide {
+  grid-column: span 1;
+  display: grid;
+  gap: 1.5rem;
+}
+
+#control-panel form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 6rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.75rem;
+  font-size: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+textarea:focus,
+input:focus,
+button:focus {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.options {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.4);
+}
+
+.status {
+  min-height: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  color: #38bdf8;
+}
+
+#answer-output {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 1rem;
+  border-radius: 12px;
+}
+
+#stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+#stats li {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.75rem;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.viz {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#graph,
+#fft-chart {
+  width: 100%;
+  height: auto;
+}
+
+.node circle {
+  stroke: rgba(255, 255, 255, 0.25);
+  stroke-width: 1.5px;
+}
+
+.node text {
+  font-size: 0.75rem;
+  pointer-events: none;
+  fill: #e2e8f0;
+}
+
+.link {
+  stroke: rgba(148, 163, 184, 0.3);
+  stroke-width: 1.5px;
+}
+
+#glyph-stream {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.glyph-card {
+  background: rgba(56, 189, 248, 0.08);
+  border-radius: 14px;
+  padding: 0.75rem;
+  min-width: 110px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.glyph-card .glyph {
+  font-size: 1.8rem;
+  text-align: center;
+}
+
+.glyph-card .label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1100px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .panel.wide {
+    grid-column: span 1;
+  }
+}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,4 +14,7 @@ def test_pipeline_offline_fallback(tmp_path):
     data = json.loads(json_out.read_text(encoding="utf-8"))
     assert "space_field" in data and "tokens" in data["space_field"]
     assert len(data["space_field"]["tokens"]) >= 1
+    assert "analytics" in data
+    assert "fft" in data["analytics"]
+    assert "glyph_stream" in data["analytics"]
     assert answer.strip()


### PR DESCRIPTION
## Summary
- add an analytics helper module that generates FFT spectra and glyph streams for the pipeline output
- update the pipeline and CLI to expose analytics data and provide an in-memory run mode for a new FastAPI GUI
- add a browser-based interface with D3 visualisations plus tests ensuring analytics payloads are emitted

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4a4cb87c8832d9da72226c4c74c78