### PR TITLE
Default CLI to localhost GUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 pytest -q
 
 run:
-hlsf run "demo prompt" --json-out out/space_field.json --text-out out/answer.txt --provider mock --passes 2
+	hlsf gui --host 127.0.0.1 --port 8000
 
 fmt:
 python -m compileall src

--- a/README.md
+++ b/README.md
@@ -13,7 +13,27 @@ python -m venv .venv && source .venv/bin/activate
 pip install -e .
 ```
 
-## Quick start (offline, mock provider)
+## Main pipeline: Localhost HTML GUI
+
+The engine's primary workflow is the interactive browser experience served from your
+machine. Running `hlsf` (with no subcommands) launches a FastAPI + Uvicorn server and
+opens `http://127.0.0.1:8000` in your default browser where the bundled `index.html`
+is hosted.
+
+```bash
+# Launch the GUI at http://127.0.0.1:8000
+hlsf
+
+# Advanced: customise host/port or skip auto-opening a browser window
+hlsf gui --host 0.0.0.0 --port 9000 --no-browser
+```
+
+From the GUI you can submit prompts, toggle LLM usage, and inspect the generated
+space field graph, FFT analytics, and glyph stream in real time. Provide LLM
+credentials via environment variables before launching the app if you want to use a
+live provider.
+
+## CLI quick start (offline, mock provider)
 ```bash
 hlsf run "Explain quantum tunneling to a 12-year-old." --provider mock --passes 2
 cat out/answer.txt
@@ -28,15 +48,18 @@ export LLM_PROVIDER=openai_compat
 export LLM_API_KEY="sk-...your key..."
 export LLM_BASE_URL="https://api.openai.com"
 export LLM_MODEL="gpt-4o-mini"    # or any compatible chat model id
-hlsf run "Summarize the benefits of spaced repetition." --passes 3
+hlsf
+# or: hlsf run "Summarize the benefits of spaced repetition." --passes 3
 ```
 
 The engine is provider-agnostic: any server exposing the OpenAI-compatible Chat Completions route will work by adjusting `LLM_BASE_URL` and `LLM_MODEL`.
 
 ## Outputs
 
-- `out/space_field.json` — Space-Field Map JSON (tokens, expansions, triangles, edges, threads)
-- `out/answer.txt` — Final answer text (LLM-refined if enabled)
+- GUI mode renders the `index.html` dashboard at `http://127.0.0.1:8000` and returns
+  analytics directly to the browser without touching disk.
+- CLI mode writes `out/space_field.json` (space-field map) and `out/answer.txt`
+  (final answer text, LLM-refined if enabled).
 
 ## Tests
 ```bash

--- a/src/hlsf/cli.py
+++ b/src/hlsf/cli.py
@@ -4,7 +4,9 @@ from .settings import Settings
 
 
 def main():
-    p = argparse.ArgumentParser(description="HLSF cognition engine (LLM-enabled)")
+    p = argparse.ArgumentParser(
+        description="HLSF cognition engine (LLM-enabled). Defaults to launching the local HTML GUI."
+    )
     sub = p.add_subparsers(dest="cmd")
 
     pr = sub.add_parser("run", help="Run HLSF on a prompt")
@@ -18,12 +20,19 @@ def main():
     pr.add_argument("--passes", type=int, default=None, help="Refinement passes (>=1)")
     pr.add_argument("--no-llm", action="store_true", help="Disable LLM usage")
 
-    pg = sub.add_parser("gui", help="Launch the interactive web interface")
+    pg = sub.add_parser("gui", help="Launch the interactive localhost web interface")
     pg.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind the GUI server")
     pg.add_argument("--port", type=int, default=8000, help="Port for the GUI server")
     pg.add_argument("--no-browser", action="store_true", help="Do not open a browser window")
 
     args = p.parse_args()
+
+    if args.cmd is None:
+        from .web.app import run_gui
+
+        run_gui()
+        return
+
     if args.cmd == "run":
         s = Settings()
         s.seed = args.seed


### PR DESCRIPTION
## Summary
- make the `hlsf` entry point launch the interactive localhost GUI by default
- document the new localhost HTML-first workflow and GUI behaviour in the README
- update the Makefile run target to start the GUI pipeline

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4a9eb5818832dafb97d3534d92eff